### PR TITLE
[protocol] pcp client post confirm protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4296,10 +4296,13 @@ dependencies = [
  "anyhow",
  "clap",
  "dotenv",
+ "hex",
  "pcp-protocol-client-core-eth",
  "pcp-protocol-client-core-util",
  "pcp-types",
+ "secure-signer-loader",
  "serde",
+ "sha3",
  "tokio",
 ]
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ f ------ | 5e771e3e47 |
 
 > FFS, just take a vote.
 
-Movement Labs' Fast Finality Settlement is a proof of stake settlement system. 
+Movement Labs' Fast Finality Settlement is a proof of stake settlement system.
 
 ## Getting started
+
 The easiest entry point for all protocols and use cases is the [`ffs-dev`](sdk/cli/ffs-dev/README.md) CLI. Subcomponents of `ffs-dev` will have their own CLIs and these CLIs have their core libraries. 
 
 To build `ffs-dev` manually you can run the following command:
@@ -29,6 +30,7 @@ The `ffs-dev` binary will then be available in `target/release/ffs-dev`.
 > We use [`clap`](https://docs.rs/clap/latest/clap/) to build our CLIs, so you can always call `--help` to get a list of available commands and their usage.
 
 ### `mcr`
+
 - `ffs-dev mcr network ...`: to spin up a network with all that you need to run MCR.
 - `ffs-dev mcr protocol client ...`: to interact with the MCR protocol from the client.
 
@@ -43,14 +45,15 @@ The `ffs-dev` binary will then be available in `target/release/ffs-dev`.
 Please see the [CONTRIBUTING.md](CONTRIBUTING.md) file for contribution guidelines.
 
 ## Organization
+
 There are five subdirectories which progressively build on one another for node logic.
 
 1. [`util`](./util): contains utility logic mainly reused in [`protocol`](./protocol).
-2. [`protocol`](./protocol): contains implementations of the protocol logic. 
+2. [`protocol`](./protocol): contains implementations of the protocol logic.
 3. [`node`](./node): contains single-process runnable binaries that aggregate the protocol logic.
 4. [`network`](./network): contains logic for running multiple nodes in a network.
 5. [`sdk`](./sdk): contains logic for interacting nodes and networks.
 
 There are several other subdirectories of note:
 
-- [`spec`](./spec): contains formal verification of FFS protocols. 
+- [`spec`](./spec): contains formal verification of FFS protocols.

--- a/node/README.md
+++ b/node/README.md
@@ -1,2 +1,3 @@
 # `node`
-The FFS Node is an independent service which is prepared to manage a fast-finality settlement connection for a given user. 
+
+The FFS Node is an independent service which is prepared to manage a fast-finality settlement connection for a given user.

--- a/protocol/pcp/cli/client/Cargo.toml
+++ b/protocol/pcp/cli/client/Cargo.toml
@@ -17,6 +17,9 @@ anyhow = { workspace = true }
 pcp-protocol-client-core-util = { workspace = true }
 pcp-protocol-client-core-eth = { workspace = true }
 pcp-types = { workspace = true }
+hex = { workspace = true }
+sha3 = "0.10.0"
+secure-signer-loader = { workspace = true }
 
 [lints]
 workspace = true

--- a/protocol/pcp/cli/client/src/cli/post_commitment/mod.rs
+++ b/protocol/pcp/cli/client/src/cli/post_commitment/mod.rs
@@ -26,22 +26,10 @@ pub struct PostCommitmentArgs {
     preimage_string: Option<String>,
 }
 
-
-
 impl PostCommitment {
-    // pub async fn execute(&self) -> Result<(), anyhow::Error> {
-    //     if let Some(hex) = &self.args.commitment_hex {
-    //         println!("Would post commitment from hex: {}", hex);
-    //     } else if let Some(preimage) = &self.args.preimage_string {
-    //         println!("Would hash and post commitment from preimage: {}", preimage);
-    //     }
-    //     Ok(())
-    // }
-
-
 	/// Handle the post commitment command.
-	pub async fn execute(&self, args: &PostCommitmentArgs) -> Result<(), anyhow::Error> {
-		let commitment = self.create_commitment(args)?;
+	pub async fn execute(&self) -> Result<(), anyhow::Error> {
+		let commitment = self.create_commitment()?;
 
 		// Get config and post commitment
 		let config = get_config()?;
@@ -55,8 +43,8 @@ impl PostCommitment {
 	}
 
     /// Create a commitment from the given arguments.
-    fn create_commitment(&self, args: &PostCommitmentArgs) -> Result<SuperBlockCommitment, anyhow::Error> {
-        if let Some(hex) = &args.commitment_hex {
+    fn create_commitment(&self) -> Result<SuperBlockCommitment, anyhow::Error> {
+        if let Some(hex) = &self.args.commitment_hex {
             // Parse hex commitment
             let bytes = hex::decode(hex)?;
             let bytes_len = bytes.len();
@@ -70,7 +58,7 @@ impl PostCommitment {
                         bytes_len * 2
                     ))?)
             ))
-        } else if let Some(preimage) = &args.preimage_string {
+        } else if let Some(preimage) = &self.args.preimage_string {
             // Hash preimage to get commitment
             let mut hasher = Keccak256::new();
             hasher.update(preimage.as_bytes());
@@ -84,10 +72,7 @@ impl PostCommitment {
             unreachable!("clap ensures one option is present")
         }
     }
-
-
 }
-
 
 /// Get the config for the PCP client.
 fn get_config() -> Result<Config, anyhow::Error> {

--- a/protocol/pcp/cli/client/src/cli/post_commitment/mod.rs
+++ b/protocol/pcp/cli/client/src/cli/post_commitment/mod.rs
@@ -1,4 +1,10 @@
-use clap::Parser;
+use clap::{Parser, Subcommand};
+use pcp_protocol_client_core_eth::config::Config;
+use pcp_protocol_client_core_util::PcpClientOperations;
+use pcp_types::block_commitment::{SuperBlockCommitment, Commitment, Id};
+use sha3::{Digest, Keccak256};
+use secure_signer_loader::identifiers::SignerIdentifier;
+use secure_signer_loader::identifiers::local::Local;
 
 #[derive(Parser)]
 #[clap(help_expected = true)]
@@ -20,13 +26,82 @@ pub struct PostCommitmentArgs {
     preimage_string: Option<String>,
 }
 
+
+
 impl PostCommitment {
-    pub async fn execute(&self) -> Result<(), anyhow::Error> {
-        if let Some(hex) = &self.args.commitment_hex {
-            println!("Would post commitment from hex: {}", hex);
-        } else if let Some(preimage) = &self.args.preimage_string {
-            println!("Would hash and post commitment from preimage: {}", preimage);
+    // pub async fn execute(&self) -> Result<(), anyhow::Error> {
+    //     if let Some(hex) = &self.args.commitment_hex {
+    //         println!("Would post commitment from hex: {}", hex);
+    //     } else if let Some(preimage) = &self.args.preimage_string {
+    //         println!("Would hash and post commitment from preimage: {}", preimage);
+    //     }
+    //     Ok(())
+    // }
+
+
+	/// Handle the post commitment command.
+	pub async fn execute(&self, args: &PostCommitmentArgs) -> Result<(), anyhow::Error> {
+		let commitment = self.create_commitment(args)?;
+
+		// Get config and post commitment
+		let config = get_config()?;
+		println!("Config: {:?}", config);
+		let client = config.build().await?;
+		println!("Starting post commitment process...");
+		client.post_block_commitment(commitment).await?;
+		println!("Successfully posted commitment");
+
+		Ok(())
+	}
+
+    /// Create a commitment from the given arguments.
+    fn create_commitment(&self, args: &PostCommitmentArgs) -> Result<SuperBlockCommitment, anyhow::Error> {
+        if let Some(hex) = &args.commitment_hex {
+            // Parse hex commitment
+            let bytes = hex::decode(hex)?;
+            let bytes_len = bytes.len();
+            Ok(SuperBlockCommitment::new(
+                0, // height
+                Id::new([0; 32]), // block id
+                Commitment::new(bytes.try_into()
+                    .map_err(|_| anyhow::anyhow!(
+                        "Invalid commitment length. Expected 32 bytes (64 hex characters), got {} bytes ({} hex characters)",
+                        bytes_len,
+                        bytes_len * 2
+                    ))?)
+            ))
+        } else if let Some(preimage) = &args.preimage_string {
+            // Hash preimage to get commitment
+            let mut hasher = Keccak256::new();
+            hasher.update(preimage.as_bytes());
+            let result = hasher.finalize();
+            Ok(SuperBlockCommitment::new(
+                0, // height
+                Id::new([0; 32]), // block id
+                Commitment::new(result.into()),
+            ))
+        } else {
+            unreachable!("clap ensures one option is present")
         }
-        Ok(())
     }
-} 
+
+
+}
+
+
+/// Get the config for the PCP client.
+fn get_config() -> Result<Config, anyhow::Error> {
+    let config = Config::new(
+        "0x1234567890123456789012345678901234567890".to_string(),  // PCP contract address
+        "http://localhost:8545".to_string(),  // RPC URL
+        "ws://localhost:8546".to_string(),  // WS URL
+        1,  // Chain ID
+        SignerIdentifier::Local(Local {
+            private_key_hex_bytes: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
+        }),
+        false,  // Run commitment admin mode
+        100000,  // Gas limit
+        3,  // Transaction send retries
+    );
+    Ok(config)
+}


### PR DESCRIPTION
## Summary

adds post confirm protocol in client. Addresses #11 but for pcp

## Testing

- `cargo run --bin ffs-client -- protocol pcp post-commitment --commitment-hex aaaaaaaaaaaaaaaaaaaaaaaa` ok
- `cargo run --bin ffs-client -- protocol pcp post-commitment --preimage-string aaa` ok