### PR TITLE
Orfile doc comments

### DIFF
--- a/sdk/cli/ffs-dev/docs/cli/README.md
+++ b/sdk/cli/ffs-dev/docs/cli/README.md
@@ -175,14 +175,14 @@ The subcommands of the `mcr-network-coordinator` CLI
 
 ###### **Subcommands:**
 
-* `where` — Run with all values passed explicitly as CLI flags
-* `using` — Load from config files, with optional env + CLI arg overrides
+* `where` — Run up with all parameters passed explicitly as CLI flags
+* `using` — Run up with parameters from environment variables, config files, and CLI flags
 
 
 
 ## `ffs-dev mcr network coordinator eth anvil up where`
 
-Run with all values passed explicitly as CLI flags
+Run up with all parameters passed explicitly as CLI flags
 
 **Usage:** `ffs-dev mcr network coordinator eth anvil up where [OPTIONS] --signer-identifier <SIGNER_IDENTIFIER> --fork-url <FORK_URL> --contract-admin <CONTRACT_ADMIN>`
 
@@ -199,7 +199,7 @@ Run with all values passed explicitly as CLI flags
 
 ## `ffs-dev mcr network coordinator eth anvil up using`
 
-Load from config files, with optional env + CLI arg overrides
+Run up with parameters from environment variables, config files, and CLI flags
 
 **Usage:** `ffs-dev mcr network coordinator eth anvil up using [OPTIONS] [EXTRA_ARGS]...`
 

--- a/util/orfile/macro/src/derive.rs
+++ b/util/orfile/macro/src/derive.rs
@@ -1,4 +1,5 @@
 use proc_macro::TokenStream;
+use proc_macro2::Literal;
 use quote::{format_ident, quote};
 use syn::{parse_macro_input, Data, DeriveInput};
 
@@ -10,6 +11,16 @@ pub fn impl_orfile(input: TokenStream) -> TokenStream {
 
 	let mod_or_file = format_ident!("or_file");
 	let mod_using = format_ident!("using");
+
+	let lower_case_struct_prefix = struct_name.to_string().to_lowercase();
+	let doc_where = Literal::string(&format!(
+		"Run {} with all parameters passed explicitly as CLI flags.",
+		lower_case_struct_prefix
+	));
+	let doc_using = Literal::string(&format!(
+		"Run {} with parameters from environment variables, config files, and CLI flags.",
+		lower_case_struct_prefix
+	));
 
 	let (config_fields, other_fields): (Vec<_>, Vec<_>) = match &input.data {
 		Data::Struct(data) => data
@@ -138,10 +149,10 @@ pub fn impl_orfile(input: TokenStream) -> TokenStream {
 
 			#[derive(clap::Subcommand, Debug, Clone)]
 			#vis enum #struct_name {
-				/// Run with all values passed explicitly as CLI flags
+				#[doc = #doc_where]
 				Where(super::#struct_name),
 
-				/// Load from config files, with optional env + CLI arg overrides
+				#[doc = #doc_using]
 				Using(#mod_using::#struct_name),
 			}
 


### PR DESCRIPTION
# Summary
Fixes `Orfile` derived comments on `where` and `using` methods. 