### PR TITLE
[client] pcp contract deployment via cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2362,94 +2362,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fcp-network"
-version = "0.0.1"
-dependencies = [
- "anyhow",
- "clap",
- "dotenv",
- "serde",
- "tokio",
-]
-
-[[package]]
-name = "fcp-network-client"
-version = "0.0.1"
-dependencies = [
- "anyhow",
- "clap",
- "dotenv",
- "serde",
- "tokio",
-]
-
-[[package]]
-name = "fcp-network-coordinator"
-version = "0.0.1"
-dependencies = [
- "anyhow",
- "clap",
- "dotenv",
- "serde",
- "tokio",
-]
-
-[[package]]
-name = "fcp-node"
-version = "0.0.1"
-dependencies = [
- "anyhow",
- "clap",
- "dotenv",
- "serde",
- "tokio",
-]
-
-[[package]]
-name = "fcp-node-client"
-version = "0.0.1"
-dependencies = [
- "anyhow",
- "clap",
- "dotenv",
- "serde",
- "tokio",
-]
-
-[[package]]
-name = "fcp-node-service"
-version = "0.0.1"
-dependencies = [
- "anyhow",
- "clap",
- "dotenv",
- "serde",
- "tokio",
-]
-
-[[package]]
-name = "fcp-protocol"
-version = "0.0.1"
-dependencies = [
- "anyhow",
- "clap",
- "dotenv",
- "serde",
- "tokio",
-]
-
-[[package]]
-name = "fcp-protocol-client"
-version = "0.0.1"
-dependencies = [
- "anyhow",
- "clap",
- "dotenv",
- "serde",
- "tokio",
-]
-
-[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2493,6 +2405,8 @@ dependencies = [
  "dotenv",
  "mcr-network",
  "mcr-protocol",
+ "pcp-network",
+ "pcp-protocol",
  "serde",
  "tokio",
 ]
@@ -2500,94 +2414,6 @@ dependencies = [
 [[package]]
 name = "ffs-environment"
 version = "0.0.1"
-
-[[package]]
-name = "ffs-network"
-version = "0.0.1"
-dependencies = [
- "anyhow",
- "clap",
- "dotenv",
- "serde",
- "tokio",
-]
-
-[[package]]
-name = "ffs-network-client"
-version = "0.0.1"
-dependencies = [
- "anyhow",
- "clap",
- "dotenv",
- "serde",
- "tokio",
-]
-
-[[package]]
-name = "ffs-network-coordinator"
-version = "0.0.1"
-dependencies = [
- "anyhow",
- "clap",
- "dotenv",
- "serde",
- "tokio",
-]
-
-[[package]]
-name = "ffs-node"
-version = "0.0.1"
-dependencies = [
- "anyhow",
- "clap",
- "dotenv",
- "serde",
- "tokio",
-]
-
-[[package]]
-name = "ffs-node-client"
-version = "0.0.1"
-dependencies = [
- "anyhow",
- "clap",
- "dotenv",
- "serde",
- "tokio",
-]
-
-[[package]]
-name = "ffs-node-service"
-version = "0.0.1"
-dependencies = [
- "anyhow",
- "clap",
- "dotenv",
- "serde",
- "tokio",
-]
-
-[[package]]
-name = "ffs-protocol"
-version = "0.0.1"
-dependencies = [
- "anyhow",
- "clap",
- "dotenv",
- "serde",
- "tokio",
-]
-
-[[package]]
-name = "ffs-protocol-client"
-version = "0.0.1"
-dependencies = [
- "anyhow",
- "clap",
- "dotenv",
- "serde",
- "tokio",
-]
 
 [[package]]
 name = "fiat-crypto"
@@ -3680,7 +3506,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "mcr-dlu-eth-deployer-eth-core"
+name = "mcr-dlu-eth-deployer-core"
 version = "0.0.1"
 dependencies = [
  "anyhow",
@@ -3730,7 +3556,7 @@ dependencies = [
  "futures",
  "kestrel",
  "mcr-config",
- "mcr-dlu-eth-deployer-eth-core",
+ "mcr-dlu-eth-deployer-core",
  "mcr-protocol-client-core-mock",
  "mcr-protocol-client-core-util",
  "mcr-types",
@@ -3762,7 +3588,7 @@ dependencies = [
  "dotenv",
  "jsonlvar",
  "kestrel",
- "mcr-dlu-eth-deployer-eth-core",
+ "mcr-dlu-eth-deployer-core",
  "mcr-network-anvil-component-core",
  "mcr-network-eth-live-component-core",
  "orfile",
@@ -3781,7 +3607,7 @@ dependencies = [
  "futures",
  "kestrel",
  "mcr-config",
- "mcr-dlu-eth-deployer-eth-core",
+ "mcr-dlu-eth-deployer-core",
  "mcr-protocol-client-core-mock",
  "mcr-protocol-client-core-util",
  "mcr-types",
@@ -3810,7 +3636,7 @@ dependencies = [
  "anyhow",
  "clap",
  "dotenv",
- "mcr-dlu-eth-deployer-eth-core",
+ "mcr-dlu-eth-deployer-core",
  "mcr-protocol-client-core-util",
  "mcr-protocol-client-eth-core",
  "mcr-types",
@@ -3886,7 +3712,7 @@ dependencies = [
  "clap",
  "dotenv",
  "jsonlvar",
- "mcr-dlu-eth-deployer-eth-core",
+ "mcr-dlu-eth-deployer-core",
  "mcr-types",
  "serde",
  "tokio",
@@ -3982,7 +3808,7 @@ dependencies = [
  "jsonlvar",
  "kestrel",
  "mcr-config",
- "mcr-dlu-eth-deployer-eth-core",
+ "mcr-dlu-eth-deployer-core",
  "mcr-protocol-client-core-mock",
  "mcr-protocol-client-core-util",
  "mcr-types",
@@ -4294,6 +4120,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "pcp-dlu-eth-deployer-core"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "async-trait",
+ "clap",
+ "commander 0.0.1",
+ "futures",
+ "hex",
+ "jsonlvar",
+ "pcp-config",
+ "pcp-protocol-client-core-mock",
+ "pcp-protocol-client-core-util",
+ "pcp-types",
+ "secure-signer",
+ "secure-signer-loader",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "walkdir",
+ "zip",
+]
+
+[[package]]
 name = "pcp-network"
 version = "0.0.1"
 dependencies = [
@@ -4327,39 +4181,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pcp-node"
-version = "0.0.1"
-dependencies = [
- "anyhow",
- "clap",
- "dotenv",
- "serde",
- "tokio",
-]
-
-[[package]]
-name = "pcp-node-client"
-version = "0.0.1"
-dependencies = [
- "anyhow",
- "clap",
- "dotenv",
- "serde",
- "tokio",
-]
-
-[[package]]
-name = "pcp-node-service"
-version = "0.0.1"
-dependencies = [
- "anyhow",
- "clap",
- "dotenv",
- "serde",
- "tokio",
-]
-
-[[package]]
 name = "pcp-protocol"
 version = "0.0.1"
 dependencies = [
@@ -4379,6 +4200,7 @@ dependencies = [
  "clap",
  "dotenv",
  "hex",
+ "pcp-dlu-eth-deployer-core",
  "pcp-protocol-client-core-eth",
  "pcp-protocol-client-core-util",
  "pcp-types",
@@ -4455,36 +4277,10 @@ dependencies = [
  "anyhow",
  "clap",
  "dotenv",
- "pcp-protocol-deployer-core-eth",
+ "pcp-dlu-eth-deployer-core",
  "pcp-types",
  "serde",
  "tokio",
-]
-
-[[package]]
-name = "pcp-protocol-deployer-core-eth"
-version = "0.0.1"
-dependencies = [
- "anyhow",
- "async-stream",
- "async-trait",
- "clap",
- "commander 0.0.1",
- "futures",
- "hex",
- "pcp-config",
- "pcp-protocol-client-core-mock",
- "pcp-protocol-client-core-util",
- "pcp-types",
- "secure-signer",
- "secure-signer-loader",
- "serde",
- "serde_json",
- "tempfile",
- "tokio",
- "tokio-stream",
- "walkdir",
- "zip",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
 
   # common
   "network/common/components/*",
+  "sdk/cli/*",
 
   # mcr
   "protocol/mcr/util/*",
@@ -19,31 +20,21 @@ members = [
   # pcp
   "protocol/pcp/util/*",
   "protocol/pcp/clients/*",
-  "protocol/pcp/cli/*",
   "protocol/pcp/dlu/eth/deployer-core",
-  ## node
-  "node/pcp/cli/*",
-  ## network
+  "protocol/pcp/cli/*",
   "network/pcp/cli/*",
+#  "node/pcp/cli/*",
 
-  # fcp
-  ## protocol
-  "protocol/fcp/cli/*",
-  ## node
-  "node/fcp/cli/*",
-  ## network
-  "network/fcp/cli/*",
+  # # fcp
+  # "protocol/fcp/cli/*",
+  # "node/fcp/cli/*",
+  # "network/fcp/cli/*",
 
-  # ffs
-  ## protocol
-  "protocol/ffs/cli/*",
-  ## node
-  "node/ffs/cli/*",
-  ## network
-  "network/ffs/cli/*",
-  ## sdk
-  "sdk/cli/*",
-
+  # # ffs
+  # "protocol/ffs/cli/*",
+  # "node/ffs/cli/*",
+  # "network/ffs/cli/*",
+  
   # util
   "util/signing/eth",
   "util/environment",
@@ -150,7 +141,7 @@ mcr-protocol-client-eth-core = { path = "protocol/mcr/clients/eth" }
 mcr-protocol-client-core-mock = { path = "protocol/mcr/clients/mock" }
 mcr-protocol-client = { path = "protocol/mcr/cli/client" }
 mcr-protocol = { path = "protocol/mcr/cli/protocol"}
-mcr-dlu-eth-deployer-eth-core = { path = "protocol/mcr/dlu/eth/deployer-core" }
+mcr-dlu-eth-deployer-core = { path = "protocol/mcr/dlu/eth/deployer-core" }
 ### network
 mcr-network-client = { path = "network/mcr/cli/client" }
 mcr-network-coordinator = { path = "network/mcr/cli/coordinator" }
@@ -166,12 +157,14 @@ pcp-protocol-client-core-util = { path = "protocol/pcp/clients/util" }
 pcp-protocol-client-core-eth = { path = "protocol/pcp/clients/eth" }
 pcp-protocol-client-core-mock = { path = "protocol/pcp/clients/mock" }
 pcp-protocol-client = { path = "protocol/pcp/cli/client" }
-pcp-protocol = { path = "protocol/pcp/cli"}
-pcp-protocol-deployer-core-eth = { path = "protocol/pcp/dlu/eth/deployer-core" }
+pcp-protocol = { path = "protocol/pcp/cli/protocol"}
+pcp-dlu-eth-deployer-core = { path = "protocol/pcp/dlu/eth/deployer-core" }
 ### network
 pcp-network-client = { path = "network/pcp/cli/client" }
 pcp-network-coordinator = { path = "network/pcp/cli/coordinator" }
 pcp-network = { path = "network/pcp/cli/network" }
+pcp-network-anvil-component-core = { path = "network/pcp/components/eth/anvil" }
+pcp-network-eth-live-component-core = { path = "network/pcp/components/eth/live" }
 
 # sdk
 ffs-dev = { path = "sdk/cli/ffs-dev" }

--- a/README_anvil.md
+++ b/README_anvil.md
@@ -51,15 +51,21 @@ export ADDRESS_B=0x70997970C51812dc3A010C7d01b50e0d17dc79C8
 Deploy the contracts using `signer_a` as deployer and `signer_b` as admin:
 
 ```bash
-./target/debug/ffs-dev mcr protocol client deploy anvil \
+./target/debug/ffs-dev pcp protocol client deploy anvil \
   --admin $ADDRESS_B \
   --private-key $PRIVATE_KEY_A
 ```
 
-After deployment, you'll see the addresses of all deployed contracts. Set the MOVE token address (`moveTokenProxy`). The default value is:
+After deployment, you'll see the addresses of all deployed contracts. Set the MOVE token address (`moveTokenProxy`).
 
+The default value for MCR is currently:
 ```bash
 export MOVE_TOKEN=0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9
+```
+
+The default value for PCP is:
+```bash
+export MOVE_TOKEN=0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9
 ```
 
 Then verify the deployment:

--- a/network/common/components/anvil/Cargo.toml
+++ b/network/common/components/anvil/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = { workspace = true }
 mcr-types = { workspace = true }
 mcr-config = { workspace = true }
 kestrel = { workspace = true }
-mcr-dlu-eth-deployer-eth-core = { workspace = true }
+mcr-dlu-eth-deployer-core = { workspace = true }
 strip-ansi-escapes = { workspace = true }
 jsonlvar = { workspace = true }
 serde = { workspace = true }

--- a/network/mcr/cli/coordinator/Cargo.toml
+++ b/network/mcr/cli/coordinator/Cargo.toml
@@ -14,7 +14,7 @@ serde = { workspace = true, features = ["derive"] }
 clap = { workspace = true}
 dotenv = { workspace = true }
 anyhow = { workspace = true }
-mcr-dlu-eth-deployer-eth-core = { workspace = true }
+mcr-dlu-eth-deployer-core = { workspace = true }
 mcr-network-anvil-component-core = { workspace = true }
 mcr-network-eth-live-component-core = { workspace = true }
 kestrel = { workspace = true }

--- a/network/mcr/components/eth/anvil/Cargo.toml
+++ b/network/mcr/components/eth/anvil/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = { workspace = true }
 mcr-types = { workspace = true }
 mcr-config = { workspace = true }
 kestrel = { workspace = true }
-mcr-dlu-eth-deployer-eth-core = { workspace = true }
+mcr-dlu-eth-deployer-core = { workspace = true }
 strip-ansi-escapes = { workspace = true }
 network-anvil-component-core = { workspace = true }
 secure-signer-loader = { workspace = true }

--- a/network/mcr/components/eth/anvil/src/dev/lifecycle/up/mod.rs
+++ b/network/mcr/components/eth/anvil/src/dev/lifecycle/up/mod.rs
@@ -1,5 +1,5 @@
 use kestrel::State;
-pub use mcr_dlu_eth_deployer_eth_core::dev::{artifacts::Artifacts, config::Config};
+pub use mcr_dlu_eth_deployer_core::dev::{artifacts::Artifacts, config::Config};
 use network_anvil_component_core::{lifecycle::up::Up as AnvilUp, util::parser::AnvilData};
 use secure_signer_loader::identifiers::{local::Local, SignerIdentifier};
 

--- a/network/mcr/components/eth/live/Cargo.toml
+++ b/network/mcr/components/eth/live/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = { workspace = true }
 mcr-types = { workspace = true }
 mcr-config = { workspace = true }
 kestrel = { workspace = true }
-mcr-dlu-eth-deployer-eth-core = { workspace = true }
+mcr-dlu-eth-deployer-core = { workspace = true }
 secure-signer-loader = { workspace = true }
 
 [dev-dependencies]

--- a/network/mcr/components/eth/live/src/dev/lifecycle/up/mod.rs
+++ b/network/mcr/components/eth/live/src/dev/lifecycle/up/mod.rs
@@ -1,5 +1,5 @@
 use kestrel::State;
-pub use mcr_dlu_eth_deployer_eth_core::dev::{artifacts::Artifacts, config::Config};
+pub use mcr_dlu_eth_deployer_core::dev::{artifacts::Artifacts, config::Config};
 
 /// Up struct for managing the MCR deployment process against Anvil.
 pub struct Up {

--- a/protocol/mcr/cli/client/Cargo.toml
+++ b/protocol/mcr/cli/client/Cargo.toml
@@ -17,7 +17,8 @@ anyhow = { workspace = true, version = "1.0.75" }
 mcr-protocol-client-core-util = { workspace = true }
 mcr-protocol-client-eth-core = { workspace = true }
 mcr-types = { workspace = true }
-mcr-dlu-eth-deployer-eth-core = { path = "../../dlu/eth/deployer-core" }
+# TODO : the naming here may not be according to the standard
+mcr-dlu-eth-deployer-core = { path = "../../dlu/eth/deployer-core" }
 
 [lints]
 workspace = true

--- a/protocol/mcr/cli/deployer/Cargo.toml
+++ b/protocol/mcr/cli/deployer/Cargo.toml
@@ -14,7 +14,7 @@ serde = { workspace = true, features = ["derive"] }
 clap = { workspace = true}
 dotenv = { workspace = true }
 anyhow = { workspace = true }
-mcr-dlu-eth-deployer-eth-core = { workspace = true }
+mcr-dlu-eth-deployer-core = { workspace = true }
 mcr-types = { workspace = true }
 jsonlvar = { workspace = true }
 

--- a/protocol/mcr/cli/deployer/src/cli/eth/deploy.rs
+++ b/protocol/mcr/cli/deployer/src/cli/eth/deploy.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use clap::Parser;
 use jsonlvar::Jsonl;
-use mcr_dlu_eth_deployer_eth_core::dev::config::Config;
+use mcr_dlu_eth_deployer_core::dev::config::Config;
 use serde::{Deserialize, Serialize};
 
 #[derive(Parser, Serialize, Deserialize, Debug, Clone)]

--- a/protocol/mcr/dlu/eth/deployer-core/Cargo.toml
+++ b/protocol/mcr/dlu/eth/deployer-core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mcr-dlu-eth-deployer-eth-core"
+name = "mcr-dlu-eth-deployer-core"
 version = { workspace = true }
 edition  = { workspace = true }
 license  = { workspace = true }

--- a/protocol/pcp/cli/client/Cargo.toml
+++ b/protocol/pcp/cli/client/Cargo.toml
@@ -20,6 +20,8 @@ pcp-types = { workspace = true }
 hex = { workspace = true }
 sha3 = "0.10.0"
 secure-signer-loader = { workspace = true }
+# TODO : the naming here may not be according to the standard
+pcp-dlu-eth-deployer-core = { path = "../../dlu/eth/deployer-core" }
 
 [lints]
 workspace = true

--- a/protocol/pcp/cli/client/src/cli/deploy/mod.rs
+++ b/protocol/pcp/cli/client/src/cli/deploy/mod.rs
@@ -1,5 +1,5 @@
 use clap::Subcommand;
-use mcr_dlu_eth_deployer_core::contracts::ContractWorkspace;
+use pcp_dlu_eth_deployer_core::contracts::ContractWorkspace;
 use std::format;
 
 #[derive(Subcommand)]
@@ -44,7 +44,7 @@ impl Deploy {
                 // - existingProxyAdmin: Admin contract for proxies
                 // - existingMoveTokenProxy: MOVE token proxy
                 // - existingStakingProxy: Staking contract proxy
-                // - existingMcrProxy: MCR protocol proxy
+                // - existingPcpProxy: PCP protocol proxy
                 // - existingAroProxy: ARO reward proxy
                 // - destroyMode: If true, nullifies all proxies (for cleanup)
                 let config = format!(
@@ -62,7 +62,7 @@ impl Deploy {
                         "existingProxyAdmin": "0x0000000000000000000000000000000000000000",
                         "existingMoveTokenProxy": "0x0000000000000000000000000000000000000000",
                         "existingStakingProxy": "0x0000000000000000000000000000000000000000",
-                        "existingMcrProxy": "0x0000000000000000000000000000000000000000",
+                        "existingPcpProxy": "0x0000000000000000000000000000000000000000",
                         "existingAroProxy": "0x0000000000000000000000000000000000000000",
                         "destroyMode": false
                     }}"#,
@@ -76,8 +76,8 @@ impl Deploy {
                     "forge",
                     [
                         "script",
-                        "script/DeployMCRDev.s.sol",
-                        "--tc", "DeployMCRDev",
+                        "script/DeployPCPDev.s.sol",
+                        "--tc", "DeployPCPDev",
                         "--rpc-url", rpc_url,
                         "--broadcast",
                         "--private-key", private_key,

--- a/protocol/pcp/cli/client/src/cli/mod.rs
+++ b/protocol/pcp/cli/client/src/cli/mod.rs
@@ -1,5 +1,6 @@
 pub mod eth;
 pub mod post_commitment;
+pub mod deploy;
 use clap::{Parser, Subcommand};
 
 /// The `pcp-protocol-client` CLI.
@@ -19,6 +20,9 @@ pub enum PcpProtocolClientSubcommand {
 	Eth(eth::Eth),
 	/// Post a commitment to an PCP implementation
 	PostCommitment(post_commitment::PostCommitment),
+	/// Deploy PCP contracts using deployer-core
+	#[clap(subcommand)]
+	Deploy(deploy::Deploy),
 }
 
 /// Implement the `From` trait for `PcpProtocolClient` to convert it into a `PcpProtocolClientSubcommand`.
@@ -48,6 +52,7 @@ impl PcpProtocolClientSubcommand {
 			PcpProtocolClientSubcommand::PostCommitment(post_commitment) => {
 				post_commitment.execute().await?
 			}
+			PcpProtocolClientSubcommand::Deploy(deploy) => deploy.execute().await?,
 		}
 		Ok(())
 	}

--- a/protocol/pcp/cli/deployer/Cargo.toml
+++ b/protocol/pcp/cli/deployer/Cargo.toml
@@ -14,8 +14,9 @@ serde = { workspace = true, features = ["derive"] }
 clap = { workspace = true}
 dotenv = { workspace = true }
 anyhow = { workspace = true }
-pcp-protocol-deployer-core-eth = { workspace = true }
 pcp-types = { workspace = true }
+# TODO : the naming here may not be according to the standard
+pcp-dlu-eth-deployer-core = { path = "../../dlu/eth/deployer-core" }
 
 [lints]
 workspace = true

--- a/protocol/pcp/cli/deployer/src/cli/eth/deploy.rs
+++ b/protocol/pcp/cli/deployer/src/cli/eth/deploy.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use clap::Parser;
-use pcp_protocol_deployer_core_eth::dev::config::Config;
+use pcp_dlu_eth_deployer_core::dev::config::Config;
 use serde::{Deserialize, Serialize};
 
 #[derive(Parser, Serialize, Deserialize, Debug, Clone)]

--- a/protocol/pcp/dlu/eth/deployer-core/Cargo.toml
+++ b/protocol/pcp/dlu/eth/deployer-core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pcp-protocol-deployer-core-eth"
+name = "pcp-dlu-eth-deployer-core"
 version = { workspace = true }
 edition  = { workspace = true }
 license  = { workspace = true }
@@ -31,6 +31,8 @@ serde = { workspace = true }
 secure-signer = { workspace = true }
 secure-signer-loader = { workspace = true }
 hex = { workspace = true }
+jsonlvar = { workspace = true }
+thiserror = { workspace = true }
 
 [build-dependencies]
 zip = { workspace = true }

--- a/protocol/pcp/dlu/eth/deployer-core/README.md
+++ b/protocol/pcp/dlu/eth/deployer-core/README.md
@@ -1,0 +1,12 @@
+# Deployer Core
+
+A Rust library that manages contract deployments for the PCP protocol. This library handles the complexities of contract deployment by providing a consistent workspace and configuration management.
+
+## Overview
+
+The deployer-core:
+
+1. Manages contract workspaces
+2. Embeds contract files (as a zip), and unzips them when needed
+3. Handles deployment configuration and contract dependencies
+4. Provides a safe interface for running deployment commands

--- a/protocol/pcp/dlu/eth/deployer-core/src/contracts/mod.rs
+++ b/protocol/pcp/dlu/eth/deployer-core/src/contracts/mod.rs
@@ -82,7 +82,7 @@ impl ContractWorkspace {
 		Ok(())
 	}
 
-	pub async fn run_command<C, I, S>(&self, command: C, args: I) -> Result<(), anyhow::Error>
+	pub async fn run_command<C, I, S>(&self, command: C, args: I) -> Result<String, anyhow::Error>
 	where
 		C: AsRef<OsStr>,
 		I: IntoIterator<Item = S>,
@@ -90,8 +90,6 @@ impl ContractWorkspace {
 	{
 		// Implementation of the run_command function
 		let path = self.get_workspace_path();
-		commander::run_command(command, args, Some(path)).await?;
-
-		Ok(())
+		commander::run_command(command, args, Some(path)).await
 	}
 }

--- a/protocol/pcp/dlu/eth/deployer-core/src/dev/artifacts/mod.rs
+++ b/protocol/pcp/dlu/eth/deployer-core/src/dev/artifacts/mod.rs
@@ -1,0 +1,43 @@
+use jsonlvar::Jsonl;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ArtifactsError {
+	#[error("JSON parsing error: {0}")]
+	Json(#[from] serde_json::Error),
+
+	#[error("Missing or invalid field: {0}")]
+	MissingField(String),
+}
+
+/// The artifacts produced by the PCP dev deployment.
+#[derive(Debug, Clone, Serialize, Deserialize, Jsonl)]
+pub struct Artifacts {
+	pub proxy_admin: String,
+
+	// Implementations
+	pub move_token_implementation: String,
+	pub staking_implementation: String,
+	pub pcp_implementation: String,
+
+	// Proxies
+	pub move_token_proxy: String,
+	pub movement_staking_proxy: String,
+	pub pcp_proxy: String,
+
+	// Commitment Admin Grants
+	pub granted_commitment_admin: String,
+
+	// Custodian Setup
+	pub pcp_custodian_epoch_duration: u64,
+
+	// Minter Roles
+	pub granted_minter_role: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MintedTokens {
+	pub recipient: String,
+	pub amount: String,
+}

--- a/protocol/pcp/dlu/eth/deployer-core/src/dev/config/mod.rs
+++ b/protocol/pcp/dlu/eth/deployer-core/src/dev/config/mod.rs
@@ -1,23 +1,27 @@
 use crate::contracts::ContractWorkspace;
-use crate::dev::deployer::Deployer;
+use crate::dev::deployer::{DeployConfig, Deployer};
 use clap::Parser;
+use jsonlvar::Jsonl;
 use secure_signer::key::TryFromCanonicalString;
 use secure_signer_loader::identifiers::SignerIdentifier;
 use serde::{Deserialize, Serialize};
 
-#[derive(Parser, Debug, Serialize, Deserialize, Clone)]
+#[derive(Parser, Debug, Serialize, Deserialize, Clone, Jsonl)]
 #[clap(help_expected = true)]
 pub struct Config {
 	/// The signer identifier.
 	#[arg(value_parser = SignerIdentifier::try_from_canonical_string)]
 	#[arg(long)]
 	pub signer_identifier: SignerIdentifier,
-	/// Whether to run in settlement admin mode.
+	/// The fork url for deployment.
 	#[arg(long)]
 	pub fork_url: String,
-	/// The gas limit for transactions.
+	/// The deployer config.
+	#[clap(flatten)]
+	pub deployer_config: DeployConfig,
+	/// The JSONL prefix to give to the output from the deployer.
 	#[arg(long)]
-	pub contract_admin: String,
+	pub jsonl_prefix: Option<String>,
 }
 
 impl Config {
@@ -25,9 +29,10 @@ impl Config {
 	pub fn new(
 		signer_identifier: SignerIdentifier,
 		fork_url: String,
-		contract_admin: String,
+		deployer_config: DeployConfig,
+		jsonl_prefix: Option<String>,
 	) -> Self {
-		Config { signer_identifier, fork_url, contract_admin }
+		Config { signer_identifier, fork_url, deployer_config, jsonl_prefix }
 	}
 
 	pub fn build(&self) -> Result<Deployer, anyhow::Error> {
@@ -38,7 +43,8 @@ impl Config {
 			workspace: ContractWorkspace::try_temp_tip()?,
 			raw_private_key,
 			fork_url: self.fork_url.clone(),
-			contract_admin: self.contract_admin.clone(),
+			config: self.deployer_config.clone(),
+			jsonl_prefix: self.jsonl_prefix.clone(),
 		})
 	}
 }

--- a/protocol/pcp/dlu/eth/deployer-core/src/dev/deployer/mod.rs
+++ b/protocol/pcp/dlu/eth/deployer-core/src/dev/deployer/mod.rs
@@ -1,4 +1,198 @@
+//! Calls a Solidity deployment script with a run method taking the following struct:
+//!
+//! struct DeployConfig {
+//!        // Admin configuration
+//!        address contractAdmin;        // Admin address for deployed contracts
+//!        
+//!        // Token configuration
+//!        string tokenName;
+//!        string tokenSymbol;
+//!        uint256 initialTokenMint;
+//!        
+//!        // Staking configuration
+//!        address[] custodians;
+//!        
+//!        // PCP configuration
+//!        uint256 initialBlockHeight;
+//!        uint256 leadingBlockTolerance;
+//!        uint256 epochDuration;
+//!        
+//!        // Reward configuration
+//!        uint8 rewardOption;              // 0=none, 1=deploy ARO, 2=existing
+//!        address existingRewardContract;  // Only used if rewardOption=2
+//!        
+//!        // Existing contracts (for upgrades)
+//!        address existingProxyAdmin;      // If set, will use this instead of deploying new
+//!        address existingMoveTokenProxy;  // If set, will upgrade this instead of deploying new
+//!        address existingStakingProxy;    // If set, will upgrade this instead of deploying new
+//!        address existingPcpProxy;        // If set, will upgrade this instead of deploying new
+//!        address existingAroProxy;        // If set, will upgrade this instead of deploying new
+//!
+//!        // Destruction flags (for destroying/nullifying contracts)
+//!        bool destroyMode;                // If true, will nullify the proxies
+//!    }
+//!
+//!
+//!
+//!
+
 use crate::contracts::ContractWorkspace;
+use crate::dev::artifacts::Artifacts;
+use clap::Parser;
+use jsonlvar::Jsonl;
+use serde::{Deserialize, Serialize};
+use serde_json;
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum PcpRewardContract {
+	None,
+	Aro,
+	Address(String),
+}
+
+impl FromStr for PcpRewardContract {
+	type Err = String;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		match s.to_lowercase().as_str() {
+			"none" => Ok(Self::None),
+			"aro" => Ok(Self::Aro),
+			addr if addr.starts_with("0x") => Ok(Self::Address(addr.to_string())),
+			_ => Err(format!("Invalid reward contract: {}. Must be 'none', 'aro', or an address starting with '0x'", s)),
+		}
+	}
+}
+
+impl PcpRewardContract {
+	pub fn reward_option(&self) -> u8 {
+		match self {
+			Self::None => 0,
+			Self::Aro => 1,
+			Self::Address(_addr) => 2,
+		}
+	}
+
+	pub fn existing_reward_contract(&self) -> Option<String> {
+		match self {
+			Self::Address(addr) => Some(addr.clone()),
+			_ => None,
+		}
+	}
+
+	pub fn reward_option_forge_arg(&self) -> String {
+		format!("{}", self.reward_option())
+	}
+
+	pub fn existing_reward_contract_forge_arg(&self) -> String {
+		match self.existing_reward_contract() {
+			Some(addr) => format!("\"{}\"", addr),
+			None => "0x0".to_string(),
+		}
+	}
+}
+
+impl Default for PcpRewardContract {
+	fn default() -> Self {
+		Self::None
+	}
+}
+
+/// Configuration for PCP deployment, matching the Solidity struct
+#[derive(Debug, Clone, Serialize, Deserialize, Jsonl, Parser)]
+pub struct DeployConfig {
+	/// Admin address for deployed contracts
+	#[arg(long)]
+	pub contract_admin: String,
+
+	/// The token name
+	#[arg(long, default_value = "Move Token")]
+	pub token_name: String,
+
+	/// The token symbol
+	#[arg(long, default_value = "MOVE")]
+	pub token_symbol: String,
+
+	/// The initial token mint
+	#[arg(long, default_value = "1000000000000000000000000")]
+	pub initial_token_mint: String,
+
+	/// The custodians
+	/// By default this should be an empty vector
+	#[arg(long)]
+	pub custodians: Option<Vec<String>>,
+
+	/// The initial block height
+	#[arg(long, default_value = "1")]
+	pub initial_block_height: String,
+
+	/// The leading block tolerance
+	#[arg(long, default_value = "10")]
+	pub leading_block_tolerance: String,
+
+	/// The epoch duration
+	#[arg(long, default_value = "1000000")]
+	pub epoch_duration: String,
+
+	/// The reward contract
+	#[arg(long)]
+	pub reward_contract: Option<PcpRewardContract>,
+
+	/// The existing proxy admin
+	#[arg(long)]
+	pub existing_proxy_admin: Option<String>,
+
+	/// The existing move token proxy
+	#[arg(long)]
+	pub existing_move_token_proxy: Option<String>,
+
+	/// The existing staking proxy
+	#[arg(long)]
+	pub existing_staking_proxy: Option<String>,
+
+	/// The existing PCP proxy
+	#[arg(long)]
+	pub existing_pcp_proxy: Option<String>,
+
+	/// The existing ARO proxy
+	#[arg(long)]
+	pub existing_reward_proxy: Option<String>,
+
+	/// Whether to destroy the contracts
+	#[arg(long, default_value = "false")]
+	pub destroy_mode: bool,
+}
+
+impl DeployConfig {
+	pub fn to_forge_arg_string(&self) -> String {
+		let reward_contract = self.reward_contract.clone().unwrap_or_default();
+		let zero_address = "0x0000000000000000000000000000000000000000";
+
+		// Create a JSON object that matches the Solidity struct's expected format
+		let json = serde_json::json!({
+			"contractAdmin": self.contract_admin,
+			"tokenName": self.token_name,
+			"tokenSymbol": self.token_symbol,
+			"initialTokenMint": self.initial_token_mint,
+			"custodians": self.custodians.as_ref().map_or(Vec::new(), |v| v.clone()),
+			"initialBlockHeight": self.initial_block_height,
+			"leadingBlockTolerance": self.leading_block_tolerance,
+			"epochDuration": self.epoch_duration,
+			"rewardOption": reward_contract.reward_option(),
+			"existingRewardContract": reward_contract.existing_reward_contract().unwrap_or_else(|| zero_address.to_string()),
+			"existingProxyAdmin": self.existing_proxy_admin.as_deref().unwrap_or(zero_address),
+			"existingMoveTokenProxy": self.existing_move_token_proxy.as_deref().unwrap_or(zero_address),
+			"existingStakingProxy": self.existing_staking_proxy.as_deref().unwrap_or(zero_address),
+			"existingPcpProxy": self.existing_pcp_proxy.as_deref().unwrap_or(zero_address),
+			"existingAroProxy": self.existing_reward_proxy.as_deref().unwrap_or(zero_address),
+			"destroyMode": self.destroy_mode
+		});
+
+		// Convert to a compact JSON string
+		let json_str = json.to_string();
+		json_str
+	}
+}
 
 /// The deployer of PCP dev contracts.
 #[derive(Debug)]
@@ -9,8 +203,10 @@ pub struct Deployer {
 	pub raw_private_key: String,
 	/// The fork url used for deployment.
 	pub fork_url: String,
-	/// The contractAdmin address used in deployment.
-	pub contract_admin: String,
+	/// The deployment configuration.
+	pub config: DeployConfig,
+	/// The jsonl prefix to give to the output from the deployer.
+	pub jsonl_prefix: Option<String>,
 }
 
 impl Deployer {
@@ -18,32 +214,37 @@ impl Deployer {
 	pub const DEPLOYMENT_SCRIPT_PATH: &'static str = "./script/DeployPCPDev.s.sol";
 
 	/// Deploys the PCP dev contracts.
-	pub async fn deploy(&self) -> Result<(), anyhow::Error> {
+	pub async fn deploy(&self) -> Result<Artifacts, anyhow::Error> {
 		// prepare the workspace directory
 		self.workspace.prepare_directory()?;
 
+		// Build command arguments
+		let mut args = vec![
+			"script",
+			Self::DEPLOYMENT_SCRIPT_PATH,
+			"--tc",
+			"DeployPCPDev",
+			"--sig",
+			"run(string)",
+		];
+
+		// Build the JSON config string
+		let config_str = self.config.to_forge_arg_string();
+		args.push(&config_str);
+
+		// Add common parameters
+		args.extend_from_slice(&[
+			"--private-key",
+			&self.raw_private_key,
+			"--fork-url",
+			&self.fork_url,
+			"--broadcast",
+		]);
+
 		// run the command for deployment
-		// todo: we would like to migrate this to use an embedded version of forge
-		self.workspace
-			.run_command(
-				"forge",
-				vec![
-					"script",
-					Self::DEPLOYMENT_SCRIPT_PATH,
-					"--sig",
-					"run(address)",
-					&self.contract_admin,
-					"--private-key",
-					&self.raw_private_key,
-					"--fork-url",
-					&self.fork_url,
-					"--broadcast",
-				],
-			)
-			.await?;
+		let log_output = self.workspace.run_command("forge", args).await?;
 
-		// todo: parse the output
-
-		Ok(())
+		// Parse the output
+		Ok(Artifacts::try_from_jsonl(&log_output, self.jsonl_prefix.as_deref())?)
 	}
 }

--- a/protocol/pcp/dlu/eth/deployer-core/src/dev/mod.rs
+++ b/protocol/pcp/dlu/eth/deployer-core/src/dev/mod.rs
@@ -1,2 +1,3 @@
+pub mod artifacts;
 pub mod config;
 pub mod deployer;

--- a/sdk/cli/ffs-dev/Cargo.toml
+++ b/sdk/cli/ffs-dev/Cargo.toml
@@ -15,9 +15,15 @@ serde = { workspace = true, features = ["derive"] }
 clap = { workspace = true}
 dotenv = { workspace = true }
 anyhow = { workspace = true }
-mcr-network = { workspace = true }
-mcr-protocol = { workspace = true}
 clap-markdown-ext = { workspace = true }
+
+# mcr
+mcr-network = { workspace = true }
+mcr-protocol = { workspace = true }
+
+# pcp
+pcp-network = { workspace = true }
+pcp-protocol = { workspace = true }
 
 [lints]
 workspace = true

--- a/sdk/cli/ffs-dev/src/cli/mod.rs
+++ b/sdk/cli/ffs-dev/src/cli/mod.rs
@@ -1,4 +1,5 @@
 pub mod mcr;
+pub mod pcp;
 
 use clap::Parser;
 use clap_markdown_ext::Markdown;
@@ -10,6 +11,8 @@ pub enum FfsDev {
 	Markdown(Markdown),
 	#[clap(subcommand)]
 	Mcr(mcr::Mcr),
+	#[clap(subcommand)]
+	Pcp(pcp::Pcp),
 }
 
 impl FfsDev {
@@ -20,6 +23,9 @@ impl FfsDev {
 			}
 			FfsDev::Mcr(mcr) => {
 				mcr.execute().await?;
+			}
+			FfsDev::Pcp(pcp) => {
+				pcp.execute().await?;
 			}
 		}
 

--- a/sdk/cli/ffs-dev/src/cli/pcp/mod.rs
+++ b/sdk/cli/ffs-dev/src/cli/pcp/mod.rs
@@ -1,0 +1,27 @@
+use clap::Parser;
+// use pcp_network::cli::PcpNetworkSubcommand;
+use pcp_protocol::cli::PcpProtocolSubcommand;
+
+#[derive(Parser)]
+#[clap(rename_all = "kebab-case")]
+pub enum Pcp {
+	// #[clap(subcommand)]
+	// Network(PcpNetworkSubcommand),
+	#[clap(subcommand)]
+	Protocol(PcpProtocolSubcommand),
+}
+
+impl Pcp {
+	pub async fn execute(&self) -> Result<(), anyhow::Error> {
+		match self {
+			// Pcp::Network(network) => {
+			// 	network.execute().await?;
+			// }
+			Pcp::Protocol(protocol) => {
+				protocol.execute().await?;
+			}
+		}
+
+		Ok(())
+	}
+}


### PR DESCRIPTION
## Summary

adds the pcp contract deployment via cli

## Testing


**Start Anvil**

```bash
anvil
```

Use the first Anvil account as the deployer (`signer_a`), and the second as the admin (`signer_b`). The following values are the default values provided by Anvil. In production, you should never use these keys.

```bash
export PRIVATE_KEY_A=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
export PRIVATE_KEY_B=0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
export ADDRESS_A=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
export ADDRESS_B=0x70997970C51812dc3A010C7d01b50e0d17dc79C8
```

<!--Then start the local Anvil network:
```bash
./target/debug/ffs-dev mcr network coordinator eth anvil up
```
-->

**Deploy Contracts**
Deploy the contracts using `signer_a` as deployer and `signer_b` as admin:

For MCR

```bash
./target/debug/ffs-dev mcr protocol client deploy anvil \
  --admin $ADDRESS_B \
  --private-key $PRIVATE_KEY_A
```

For PCP

```bash
./target/debug/ffs-dev pcp protocol client deploy anvil \
  --admin $ADDRESS_B \
  --private-key $PRIVATE_KEY_A
```

After deployment, you'll see the addresses of all deployed contracts. Set the MOVE token address (`moveTokenProxy`).

The default value for MCR is currently:
```bash
export MOVE_TOKEN=0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9
```

The default value for PCP is:
```bash
export MOVE_TOKEN=0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9
```

Then verify the deployment:

```bash
echo -n " Token Symbol: "
cast call $MOVE_TOKEN "symbol()" --rpc-url http://localhost:8545 | tr -d '\n' | cast --to-ascii
echo -n "Total Supply: "
cast call $MOVE_TOKEN "totalSupply()" --rpc-url http://localhost:8545 | cast --to-dec | xargs -I {} echo "scale=8; {}/100000000" | bc
echo -n "Balance of admin: "
cast call $MOVE_TOKEN "balanceOf(address)" $ADDRESS_B --rpc-url http://localhost:8545 | cast --to-dec | xargs -I {} echo "scale=8; {}/100000000" | bc
```
